### PR TITLE
Add grpc and http2 to gateway listeners

### DIFF
--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -101,8 +101,9 @@ envoy_gateway_bind_addresses "<service>" {
 #### `listener` Parameters
 
 - `port` `(int: required)` - The port that the listener should receive traffic on.
-- `protocol` `(string: "tcp")` - The protocol associated with the listener. Either
-  `tcp` or `http`.
+- `protocol` `(string: "tcp")` - 'The protocol associated with the listener. 
+  One of `tcp`, `http`, `http2`, or `grpc`.',
+  
 
   ~> **Note:** If using `http`, preconfiguring a [service-default] in Consul to
   set the [Protocol](https://www.consul.io/docs/agent/config-entries/service-defaults#protocol)

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -102,7 +102,7 @@ envoy_gateway_bind_addresses "<service>" {
 
 - `port` `(int: required)` - The port that the listener should receive traffic on.
 - `protocol` `(string: "tcp")` - 'The protocol associated with the listener. 
-  One of `tcp`, `http`, `http2`, or `grpc`.',
+   One of `tcp`, `http`, `http2`, or `grpc`.',
   
 
   ~> **Note:** If using `http`, preconfiguring a [service-default] in Consul to


### PR DESCRIPTION
Stating at Nomad version 1.2.0 `grpc` and `http2` [protocols are supported](https://github.com/hashicorp/nomad/pull/11187)